### PR TITLE
Allow for test powershell script to be run from any folder

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  "recommendations": [
-    "editorconfig.editorconfig",
-    "ms-vscode.powershell"
-  ]
+  "recommendations": ["editorconfig.editorconfig", "ms-vscode.powershell"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "editor.rulers": [100],
   "powershell.codeFormatting.preset": "OTBS",
   "workbench.colorCustomizations": {
-    "statusBar.background" : "#303030"
+    "statusBar.background": "#303030"
   }
 }

--- a/script/bin/checkScripts.ps1
+++ b/script/bin/checkScripts.ps1
@@ -20,12 +20,20 @@ if ($PSBoundParameters.ContainsKey('Test')) {
     $hints += $results.Where( { $_.Severity -eq 'Information' }).Count
   }
 } else {
-  Write-Output "Analysing all scripts..."
-  Invoke-ScriptAnalyzer -Path .\script -Recurse
-  $results = Invoke-ScriptAnalyzer -Path .\script -Recurse -ReportSummary
+  $binPath = Split-Path -Path $PSCommandPath -Parent
+  $scriptPath = Split-Path -Path $binPath -Parent
+  Push-Location "$scriptPath"
+  Write-Output "Change directory to: $(Get-Location)"
+
+  Write-Output "Analysing all PowerShell scripts..."
+  Invoke-ScriptAnalyzer -Path . -Recurse
+  $results = Invoke-ScriptAnalyzer -Path . -Recurse -ReportSummary
   $errors += $results.Where( { $_.Severity -eq 'Error' }).Count
   $warnings += $results.Where( { $_.Severity -eq 'Warning' }).Count
   $hints += $results.Where( { $_.Severity -eq 'Information' }).Count
+
+  Pop-Location
+  Write-Output "Change directory back to: $(Get-Location)"
 }
 
 # In this case even hints are considered a problem and will produce a non-zero exit code


### PR DESCRIPTION
There was an assumption that the script was being run from the root of the project as it just ran checks against a relative script folder.
Also some minor fixes to the vs code settings.